### PR TITLE
cleanup-for-release

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,5 +146,15 @@ and [stunnel](http://linux.die.net/man/8/stunnel) configurations to see what set
 - `ENABLE_STUNNEL_AMAZON_RDS_FIX` Default is unset. Set this var if you are connecting to an Amazon RDS instance of postgres.
  Adds `options = NO_TICKET` which is documented to make stunnel work correctly after a dyno resumes from sleep. Otherwise, the dyno will lose connectivity to RDS.
 - `PGBOUNCER_IGNORE_STARTUP_PARAMETERS` Adds parameters to ignore when pgbouncer is starting. Some postgres libraries, like Go's pq, append this parameter, making it impossible to use this buildpack. Default is empty and the most common ignored parameter is `extra_float_digits`. Multiple parameters can be seperated via commas. Example: `PGBOUNCER_IGNORE_STARTUP_PARAMETERS="extra_float_digits, some_other_param"`
+- `PGBOUNCER_PKT_BUF` Default is 4096.
+- `PGBOUNCER_MAX_PACKET_SIZE` Default is 2147483647.
+- `PGBOUNCER_LISTEN_BACKLOG` Default is 128.
+- `PGBOUNCER_SBUF_LOOPCNT` Default is 5.
+- `PGBOUNCER_SUSPEND_TIMEOUT` Default is 10.
+- `PGBOUNCER_TCP_DEFER_ACCEPT` Default is 45.
+- `PGBOUNCER_TCP_KEEPALIVE` Default is 1.
+- `PGBOUNCER_TCP_KEEPCNT` Default is 9.
+- `PGBOUNCER_TCP_KEEPIDLE` Default is 7200.
+- `PGBOUNCER_TCP_KEEPINTVL` Default is 75.
 
 For more info, see [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -156,5 +156,4 @@ and [stunnel](http://linux.die.net/man/8/stunnel) configurations to see what set
 - `PGBOUNCER_TCP_KEEPCNT` Default is 9.
 - `PGBOUNCER_TCP_KEEPIDLE` Default is 7200.
 - `PGBOUNCER_TCP_KEEPINTVL` Default is 75.
-
-For more info, see [CONTRIBUTING.md](CONTRIBUTING.md)
+- `PGBOUNCER_STATS_USERNAME` and `PGBOUNCER_STATS_PASSWORD` Set these to enable stats_users SHOW access to pgbouncer.

--- a/README.md
+++ b/README.md
@@ -157,3 +157,5 @@ and [stunnel](http://linux.die.net/man/8/stunnel) configurations to see what set
 - `PGBOUNCER_TCP_KEEPIDLE` Default is 7200.
 - `PGBOUNCER_TCP_KEEPINTVL` Default is 75.
 - `PGBOUNCER_STATS_USERNAME` and `PGBOUNCER_STATS_PASSWORD` Set these to enable stats_users SHOW access to pgbouncer.
+
+For more info, see [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -66,13 +66,10 @@ ignore_startup_parameters = ${PGBOUNCER_IGNORE_STARTUP_PARAMETERS}
 ; tcp_keepcnt, tcp_keepidle, and tcp_keepidle, supported with defaults
 ; for Linux as documented above.
 ;
-; tcp_socket_buffer not supported because I could not find a sensible
-; documented default.
-;
-; I also confirmed these settings and their defaults are supported in
-; pgbouncer 1.7, not just pgbouncer HEAD:
+; These defaults match both pgbouncer 1.7 and pgbouncer HEAD.
 ;
 ;   https://github.com/pgbouncer/pgbouncer/blob/pgbouncer_1_7/etc/pgbouncer.ini
+;   https://github.com/pgbouncer/pgbouncer/blob/master/etc/pgbouncer.ini
 ;
 pkt_buf = ${PGBOUNCER_PKT_BUF:-4096}
 max_packet_size = ${PGBOUNCER_MAX_PACKET_SIZE:-2147483647}
@@ -84,14 +81,24 @@ tcp_keepalive = ${PGBOUNCER_TCP_KEEPALIVE:-1}
 tcp_keepcnt = ${PGBOUNCER_TCP_KEEPCNT:-9}
 tcp_keepidle = ${PGBOUNCER_TCP_KEEPIDLE:-7200}
 tcp_keepintvl = ${PGBOUNCER_TCP_KEEPINTVL:-75}
+EOFEOF
 
-; PW modification: enable hard-coded user name which can issue the
-; SHOW commands to get stats from pgbouncer.
-;
-; - jhw@prosperworks.com, 2016-02-09
-;
-stats_users = pgbouncer-stats
+# If PGBOUNCER_STATS_USERNAME and PGBOUNCER_STATS_PASSWORD are
+# defined, enable SHOW commands from pgbouncer with those credentials.
+#
+rm -f /app/vendor/pgbouncer/users.txt
+if [ -n "$PGBOUNCER_STATS_USERNAME" ] && [ -n "$PGBOUNCER_STATS_PASSWORD" ]
+then
+    STATS_MD5_PASS="md5"`echo -n ${PGBOUNCER_STATS_USERNAME}${PGBOUNCER_STATS_PASSWORD} | md5sum | awk '{print $1}'`
+    cat >> /app/vendor/pgbouncer/pgbouncer.ini << EOFEOF
+stats_users = $PGBOUNCER_STATS_USERNAME
+EOFEOF
+    cat >> /app/vendor/pgbouncer/users.txt << EOFEOF
+"$PGBOUNCER_STATS_USERNAME" "$STATS_MD5_PASS"
+EOFEOF
+fi
 
+cat >> /app/vendor/pgbouncer/pgbouncer.ini << EOFEOF
 [databases]
 EOFEOF
 
@@ -124,7 +131,6 @@ EOFEOF
 
   cat >> /app/vendor/pgbouncer/users.txt << EOFEOF
 "$DB_USER" "$DB_MD5_PASS"
-"pgbouncer-stats" "md572c5dd36a292efeaf13075b5eeb28693"
 EOFEOF
 
   cat >> /app/vendor/pgbouncer/pgbouncer.ini << EOFEOF
@@ -133,23 +139,6 @@ EOFEOF
 
   let "n += 1"
 done
-
-# The password field for pgbouncer-stats was computed like so:
-#
-#   echo -n PASSWORDpgbouncer-stats | md5sum | awk '{print "md5" $1}'
-#
-# ...except PASSWORD was something else.  See ali/bin/launcher.sh for
-# the actual password.
-#
-# This is much like above where DB_MD5_PASS is calculated, and also
-# per https://pgbouncer.github.io/config.html, in the section
-# "Authentication file format".
-#
-# - jhw@prosperworks.com, 2016-02-09
-#
-cat >> /app/vendor/pgbouncer/users.txt << EOFEOF
-"pgbouncer-stats" "md572c5dd36a292efeaf13075b5eeb28693"
-EOFEOF
 
 chmod go-rwx /app/vendor/pgbouncer/*
 chmod go-rwx /app/vendor/stunnel/*

--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -122,20 +122,6 @@ connect = $DB_HOST:$DB_PORT
 retry = ${PGBOUNCER_CONNECTION_RETRY:-"no"}
 EOFEOF
 
-
-  # The password field for pgbouncer-stats was computed like so:
-  #
-  #   echo -n PASSWORDpgbouncer-stats | md5sum | awk '{print "md5" $1}'
-  #
-  # ...except PASSWORD was something else.  See ali/bin/launcher.sh
-  # for the actual password.
-  #
-  # This is much like above where DB_MD5_PASS is calculated, and also
-  # per https://pgbouncer.github.io/config.html, in the section
-  # "Authentication file format".
-  #
-  # - jhw@prosperworks.com, 2016-02-09
-  #
   cat >> /app/vendor/pgbouncer/users.txt << EOFEOF
 "$DB_USER" "$DB_MD5_PASS"
 "pgbouncer-stats" "md572c5dd36a292efeaf13075b5eeb28693"
@@ -147,6 +133,23 @@ EOFEOF
 
   let "n += 1"
 done
+
+# The password field for pgbouncer-stats was computed like so:
+#
+#   echo -n PASSWORDpgbouncer-stats | md5sum | awk '{print "md5" $1}'
+#
+# ...except PASSWORD was something else.  See ali/bin/launcher.sh for
+# the actual password.
+#
+# This is much like above where DB_MD5_PASS is calculated, and also
+# per https://pgbouncer.github.io/config.html, in the section
+# "Authentication file format".
+#
+# - jhw@prosperworks.com, 2016-02-09
+#
+cat >> /app/vendor/pgbouncer/users.txt << EOFEOF
+"pgbouncer-stats" "md572c5dd36a292efeaf13075b5eeb28693"
+EOFEOF
 
 chmod go-rwx /app/vendor/pgbouncer/*
 chmod go-rwx /app/vendor/stunnel/*

--- a/test/gen-pgbouncer-conf.sh.bats
+++ b/test/gen-pgbouncer-conf.sh.bats
@@ -16,21 +16,27 @@ load helper
   assert test -f /app/vendor/pgbouncer/pgbouncer.ini
 }
 
+@test "generates /app/vendor/pgbouncer/users.txt" {
+  rm -f /app/vendor/pgbouncer/users.txt
+  run bash bin/gen-pgbouncer-conf.sh
+  assert_success
+  assert test -f /app/vendor/pgbouncer/users.txt
+}
+
 @test "env overrides for pgbouncer low-level network settings" {
-  export PGBOUNCER_PKT_BUF="XXX_PKT_BUF"
-  export PGBOUNCER_MAX_PACKET_SIZE="XXX_MAX_PACKET_SIZE"
-  export PGBOUNCER_LISTEN_BACKLOG="XXX_LISTEN_BACKLOG"
-  export PGBOUNCER_SBUF_LOOPCNT="XXX_SBUF_LOOPCNT"
-  export PGBOUNCER_SUSPEND_TIMEOUT="XXX_SUSPEND_TIMEOUT"
-  export PGBOUNCER_TCP_DEFER_ACCEPT="XXX_TCP_DEFER_ACCEPT"
-  export PGBOUNCER_TCP_KEEPALIVE="XXX_TCP_KEEPALIVE"
-  export PGBOUNCER_TCP_KEEPCNT="XXX_TCP_KEEPCNT"
-  export PGBOUNCER_TCP_KEEPIDLE="XXX_TCP_KEEPIDLE"
-  export PGBOUNCER_TCP_KEEPINTVL="XXX_TCP_KEEPINTVL"
+  export PGBOUNCER_PKT_BUF=XXX_PKT_BUF
+  export PGBOUNCER_MAX_PACKET_SIZE=XXX_MAX_PACKET_SIZE
+  export PGBOUNCER_LISTEN_BACKLOG=XXX_LISTEN_BACKLOG
+  export PGBOUNCER_SBUF_LOOPCNT=XXX_SBUF_LOOPCNT
+  export PGBOUNCER_SUSPEND_TIMEOUT=XXX_SUSPEND_TIMEOUT
+  export PGBOUNCER_TCP_DEFER_ACCEPT=XXX_TCP_DEFER_ACCEPT
+  export PGBOUNCER_TCP_KEEPALIVE=XXX_TCP_KEEPALIVE
+  export PGBOUNCER_TCP_KEEPCNT=XXX_TCP_KEEPCNT
+  export PGBOUNCER_TCP_KEEPIDLE=XXX_TCP_KEEPIDLE
+  export PGBOUNCER_TCP_KEEPINTVL=XXX_TCP_KEEPINTVL
   rm -f /app/vendor/pgbouncer/pgbouncer.ini
   run bash bin/gen-pgbouncer-conf.sh
   assert_success
-  assert test -f /app/vendor/pgbouncer/pgbouncer.ini
   assert grep 'pkt_buf = XXX_PKT_BUF' /app/vendor/pgbouncer/pgbouncer.ini
   assert grep 'max_packet_size = XXX_MAX_PACKET_SIZE' /app/vendor/pgbouncer/pgbouncer.ini
   assert grep 'listen_backlog = XXX_LISTEN_BACKLOG' /app/vendor/pgbouncer/pgbouncer.ini
@@ -41,4 +47,49 @@ load helper
   assert grep 'tcp_keepcnt = XXX_TCP_KEEPCNT' /app/vendor/pgbouncer/pgbouncer.ini
   assert grep 'tcp_keepidle = XXX_TCP_KEEPIDLE' /app/vendor/pgbouncer/pgbouncer.ini
   assert grep 'tcp_keepintvl = XXX_TCP_KEEPINTVL' /app/vendor/pgbouncer/pgbouncer.ini
+}
+
+@test "no stats_users if not configured" {
+  rm -f /app/vendor/pgbouncer/pgbouncer.ini
+  run bash bin/gen-pgbouncer-conf.sh
+  assert_success
+  assert grep -v stats_users /app/vendor/pgbouncer/pgbouncer.ini
+}
+
+@test "no stats_users if half-configured" {
+  export PGBOUNCER_STATS_USERNAME=cognoscente
+  rm -f /app/vendor/pgbouncer/pgbouncer.ini
+  run bash bin/gen-pgbouncer-conf.sh
+  assert_success
+  assert grep -v cognoscente /app/vendor/pgbouncer/pgbouncer.ini
+}
+
+@test "no stats_users if other half-configured" {
+  export PGBOUNCER_STATS_PASSWORD=arcanus
+  rm -f /app/vendor/pgbouncer/pgbouncer.ini
+  run bash bin/gen-pgbouncer-conf.sh
+  assert_success
+  assert grep -v arcanus /app/vendor/pgbouncer/pgbouncer.ini
+}
+
+@test "stats_users if fully configured" {
+  export PGBOUNCER_STATS_USERNAME=cognoscente
+  export PGBOUNCER_STATS_PASSWORD=arcanus
+  rm -f /app/vendor/pgbouncer/pgbouncer.ini
+  run bash bin/gen-pgbouncer-conf.sh
+  assert_success
+  #
+  # pgbouncer.ini should contain the username but no form of the
+  # password.
+  #
+  assert grep    cognoscente    /app/vendor/pgbouncer/pgbouncer.ini
+  assert grep -v arcanus        /app/vendor/pgbouncer/pgbouncer.ini
+  assert grep -v 'md5468.*559c' /app/vendor/pgbouncer/users.txt
+  #
+  # user.txt should contain the username and the hashed form of the
+  # password but not the plaintext password.
+  #
+  assert grep    cognoscente    /app/vendor/pgbouncer/users.txt
+  assert grep -v arcanus        /app/vendor/pgbouncer/users.txt
+  assert grep    'md5468.*559c' /app/vendor/pgbouncer/users.txt
 }


### PR DESCRIPTION
PR for heroku-buildpack-pgbouncer.

Cleans up many of our local PW changes, to make them more suitable for a pull request back to the upstream community.

Removes my name, makes some of our usernames and passwords ENV-configurable instead of hardcoded, and documents more in README.md.

Those usernames and passwords are still in the history so I will have to be careful how I construct the merge back upstream.