### PR TITLE
fix-hashing

### DIFF
--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -89,7 +89,7 @@ EOFEOF
 rm -f /app/vendor/pgbouncer/users.txt
 if [ -n "$PGBOUNCER_STATS_USERNAME" ] && [ -n "$PGBOUNCER_STATS_PASSWORD" ]
 then
-    STATS_MD5_PASS="md5"`echo -n ${PGBOUNCER_STATS_USERNAME}${PGBOUNCER_STATS_PASSWORD} | md5sum | awk '{print $1}'`
+    STATS_MD5_PASS="md5"`echo -n ${PGBOUNCER_STATS_PASSWORD}${PGBOUNCER_STATS_USERNAME} | md5sum | awk '{print $1}'`
     cat >> /app/vendor/pgbouncer/pgbouncer.ini << EOFEOF
 stats_users = $PGBOUNCER_STATS_USERNAME
 EOFEOF

--- a/test/gen-pgbouncer-conf.sh.bats
+++ b/test/gen-pgbouncer-conf.sh.bats
@@ -84,14 +84,14 @@ load helper
   #
   assert grep    cognoscente    /app/vendor/pgbouncer/pgbouncer.ini
   assert grep -v arcanus        /app/vendor/pgbouncer/pgbouncer.ini
-  assert grep -v 'md5468.*559c' /app/vendor/pgbouncer/users.txt
+  assert grep -v 'md5e98.*12d3' /app/vendor/pgbouncer/users.txt
   #
   # user.txt should contain the username and the hashed form of the
   # password but not the plaintext password.
   #
   assert grep    cognoscente    /app/vendor/pgbouncer/users.txt
   assert grep -v arcanus        /app/vendor/pgbouncer/users.txt
-  assert grep    'md5468.*559c' /app/vendor/pgbouncer/users.txt
+  assert grep    'md5e98.*12d3' /app/vendor/pgbouncer/users.txt
 }
 
 @test "specific known-good username password pair" {
@@ -100,5 +100,5 @@ load helper
   rm -f /app/vendor/pgbouncer/pgbouncer.ini
   run bash bin/gen-pgbouncer-conf.sh
   assert_success
-  assert grep 'md572c5dd36a292efeaf13075b5eeb28693' /app/vendor/pgbouncer/users.txt
+  assert grep 'md572c.*693' /app/vendor/pgbouncer/users.txt
 }

--- a/test/gen-pgbouncer-conf.sh.bats
+++ b/test/gen-pgbouncer-conf.sh.bats
@@ -93,3 +93,12 @@ load helper
   assert grep -v arcanus        /app/vendor/pgbouncer/users.txt
   assert grep    'md5468.*559c' /app/vendor/pgbouncer/users.txt
 }
+
+@test "specific known-good username password pair" {
+  export PGBOUNCER_STATS_USERNAME=pgbouncer-stats
+  export PGBOUNCER_STATS_PASSWORD=naked
+  rm -f /app/vendor/pgbouncer/pgbouncer.ini
+  run bash bin/gen-pgbouncer-conf.sh
+  assert_success
+  assert grep 'md572c5dd36a292efeaf13075b5eeb28693' /app/vendor/pgbouncer/users.txt
+}


### PR DESCRIPTION
PR for https://github.com/ProsperWorks/heroku-buildpack-pgbouncer.

I goofed in https://github.com/ProsperWorks/heroku-buildpack-pgbouncer/pull/5.  I got the computation for the hash of the stats_user credentials reversed.

My tests didn't include some known-good comparables. :(