### PR TITLE
H-B-PGBOUNCER support-server_connect_timeout

### DIFF
--- a/bin/gen-pgbouncer-conf.sh
+++ b/bin/gen-pgbouncer-conf.sh
@@ -35,6 +35,7 @@ reserve_pool_size = ${PGBOUNCER_RESERVE_POOL_SIZE:-1}
 reserve_pool_timeout = ${PGBOUNCER_RESERVE_POOL_TIMEOUT:-5.0}
 server_lifetime = ${PGBOUNCER_SERVER_LIFETIME:-3600}
 server_idle_timeout = ${PGBOUNCER_SERVER_IDLE_TIMEOUT:-600}
+server_connect_timeout = ${PGBOUNCER_SERVER_CONNECT_TIMEOUT:-15}
 log_connections = ${PGBOUNCER_LOG_CONNECTIONS:-1}
 log_disconnections = ${PGBOUNCER_LOG_DISCONNECTIONS:-1}
 log_pooler_errors = ${PGBOUNCER_LOG_POOLER_ERRORS:-1}


### PR DESCRIPTION
PR for `heroku-buildpack-pgbouncer`.

Support forwarding another parameter from env to `pgbouncer.ini`.

Companion to https://github.com/ProsperWorks/ALI/pull/11458.