### PR TITLE
Absolute path for tar step

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -45,7 +45,7 @@ VENDORED_PGBOUNCER="vendor/pgbouncer"
 PATH="$BUILD_DIR/$VENDORED_PGBOUNCER/bin:$PATH"
 echo "-----> Fetching and vendoring pgbouncer into slug"
 mkdir -p "$BUILD_DIR/$VENDORED_PGBOUNCER"
-tar xzf pgbouncer-${PGBOUNCER_VERSION}.tgz -C ${BUILD_DIR}/${VENDORED_PGBOUNCER}
+tar xzf "${BUILDPACK_DIR}/pgbouncer-${PGBOUNCER_VERSION}.tgz" -C ${BUILD_DIR}/${VENDORED_PGBOUNCER}
 
 echo "-----> Moving the configuration generation script into app/bin"
 mkdir -p $BUILD_DIR/bin


### PR DESCRIPTION
This untar step fails when I move the buildpack into its own docker layer rather than every buildpack happening in one layer. I'm not sure what leakage is making it work.
Rather than hack around it by setting env vars in the dockerfile I'd rather we make the buildpack specify an absolute path instead of a relative one, that way it doesn't matter what the working dir is when executing the script.

This won't break onebox or ALI because they both specify a commit sha for this buildpack.